### PR TITLE
Melhoria no jsonformatter / remoção .nuget no .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,7 @@ publish/
 # NuGet Packages Directory
 ## TODO: If you have NuGet Package Restore enabled, uncomment the next line
 #packages/
+.nuget/
 
 # Windows Azure Build Output
 csx

--- a/Ticket.Usuarios.API.V4.Web/App_Start/WebApiConfig.cs
+++ b/Ticket.Usuarios.API.V4.Web/App_Start/WebApiConfig.cs
@@ -1,25 +1,31 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web.Http;
-using Ticket.API.Shared.Infrastructure;
+﻿using System.Web.Http;
 
 namespace Ticket.Usuarios.API.V4.Web
 {
+    using Newtonsoft.Json.Serialization;
+
     public static class WebApiConfig
     {
         public static void Register(HttpConfiguration config)
         {
             // Web API configuration and services
 
+            // Use camel case for JSON data.
+            config.Formatters.JsonFormatter.SerializerSettings.ContractResolver = new CamelCasePropertyNamesContractResolver();
+
+            // Remove XML formatter.
+            var formatters = GlobalConfiguration.Configuration.Formatters;
+            formatters.Remove(formatters.XmlFormatter);
+
             // Web API routes
             config.MapHttpAttributeRoutes();
-
+            
             config.Routes.MapHttpRoute(
                 name: "Usuario_ID",
                 routeTemplate: "usuarios/v4/{id}",
                 defaults: new { controller = "UsuariosV4", action = "GetById" }
             );
+
             config.Routes.MapHttpRoute(
                name: "Busca_Usuarios",
                routeTemplate: "usuarios/v4/",

--- a/Ticket.Usuarios.API.V4.Web/Controllers/UsuariosV4Controller.cs
+++ b/Ticket.Usuarios.API.V4.Web/Controllers/UsuariosV4Controller.cs
@@ -69,7 +69,7 @@ namespace Ticket.Usuarios.API.V4.Web.Controllers
 
             UsuarioResourceAssembler.AddRelationLinks(usuario, Request.RequestUri);
 
-            return Json<UsuarioRepresentation>(usuario);
+            return Ok(usuario);
 
         }
     }

--- a/Ticket.Usuarios.API.V4/Representations/UsuarioRepresentation.cs
+++ b/Ticket.Usuarios.API.V4/Representations/UsuarioRepresentation.cs
@@ -1,29 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.ComponentModel.DataAnnotations;
-using System.Runtime.Serialization;
-using Newtonsoft.Json;
+﻿using System.Collections.Generic;
 
 namespace Ticket.Usuarios.API.V4.Representations
 {
     public class UsuarioRepresentation
     {
-        [JsonProperty(PropertyName = "id")]
         public virtual int Id { get; set; }
-        [JsonProperty(PropertyName =  "nome")]
         public virtual string Nome { get; set; }
-        [JsonProperty(PropertyName =  "email")]
         public virtual string Email { get; set; }
-        [JsonProperty(PropertyName =  "aceitoMkt")]
         public virtual bool AceitoMkt { get; set; }
-        [JsonProperty(PropertyName =  "statusValidacao")]
         public virtual int StatusValidacao { get; set; }
-        [JsonProperty(PropertyName =  "links")]
         public virtual List<LinkRelation> Links { get; set; }
-        [JsonProperty(PropertyName =  "telefone")]
         public virtual AparelhoTelefoneRepresentation Telefone { get; set; }
             
     }
@@ -31,13 +17,9 @@ namespace Ticket.Usuarios.API.V4.Representations
     public class AparelhoTelefoneRepresentation
     {
 
-        [JsonProperty(PropertyName =  "numero")]
         public virtual string Numero { get; private set; }
-        [JsonProperty(PropertyName = "idAparelho")]
         public virtual string UUID { get; private set; }
-        [JsonProperty(PropertyName = "sistemaOperacional")]
         public virtual string SistemaOperacional { get; private set; }
-        [JsonProperty(PropertyName = "validado")]
         public virtual bool Validado { get; private set; }
     }
 }


### PR DESCRIPTION
Alex,

O pull request possui 2 commits:

1) Inclui no .gitignore a regra para exclusão da pasta .nuget.

2) Adicionei no WebApiConfig uma linha para sobrescrever o ContractResolver do SerializerSettings pelo CamelCasePropertyNamesContractResolver do Newtonsoft.Json, com isso eliminando a necessidade de anotar as propriedades com o 'JsonProperty'. Outra alteração é que tornei o retorno Json como padrão demovendo o XmlFormatter.